### PR TITLE
Fixing clap 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.5"
+version = "3.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feff3878564edb93745d58cf63e17b63f24142506e7a20c87a5521ed7bfb1d63"
+checksum = "967965e82fc46fee1a88147a7a977a66d615ed5f83eb95b18577b342c08f90ff"
 dependencies = [
  "atty",
  "bitflags",
@@ -75,14 +75,13 @@ dependencies = [
  "strsim",
  "termcolor",
  "textwrap",
- "unicase",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.5"
+version = "3.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b15c6b4f786ffb6192ffe65a36855bc1fc2444bcd0945ae16748dcd6ed7d0d3"
+checksum = "85946d4034625800196413478a1c6d3a57c12785e1f3970e590e0137dfa07342"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -171,9 +170,9 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -223,9 +222,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "os_str_bytes"
-version = "4.2.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addaa943333a514159c80c97ff4a93306530d965d27e139188283cd13e06a799"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
 ]
@@ -370,30 +369,12 @@ name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,12 @@ categories = ["command-line-utilities"]
 serde_yaml = "^0.8.17"
 fs_extra = "^1.2.0"
 dirs = "^3.0.1"
-clap = "3.0.0-beta.5"
 scanln = "0.1.1"
 
 [dependencies.serde]
 version = "^1.0.125"
+features = ["derive"]
+
+[dependencies.clap]
+version = "3.0.0-rc.4"
 features = ["derive"]

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -7,17 +7,19 @@ use clap::Parser;
 )]
 #[clap(version = env!("CARGO_PKG_VERSION"), author = "Takasakiii <lucasmc2709@live.com>")]
 pub struct LaunchOptions {
-    #[clap(short, long, about = "Enables verbose mode for debugging.")]
+    /// Enables verbose mode for debugging
+    #[clap(short, long)]
     pub verbose: bool,
-    #[clap(default_value = "Default", about = "Profile name.")]
+
+    /// Profile name
+    #[clap(default_value = "Default")]
     pub profile: String,
-    #[clap(about = "Workflow folder. ")]
+
+    /// Workflow folder
     pub path: Option<String>,
-    #[clap(
-        short,
-        long,
-        about = "Changes the 'derive' of the 'Default' profile to another one."
-    )]
+
+    /// Changes the 'derive' of the 'Default' profile to another one
+    #[clap(short, long)]
     pub base_derive: Option<String>,
 }
 

--- a/src/configs/config.rs
+++ b/src/configs/config.rs
@@ -61,7 +61,7 @@ impl Config {
 
                 if let Ok(yml) = serde_yaml::to_string(&obj) {
                     if let Err(why) = file.write_all(yml.as_bytes()) {
-                        println!("Config não pode ser gravado, {:?}", why);
+                        println!("Config não pôde ser gravado, {:?}", why);
                     }
                 }
             }

--- a/src/configs/dirs_and_files.rs
+++ b/src/configs/dirs_and_files.rs
@@ -37,7 +37,7 @@ pub fn get_bin_or_cmd_name<'a>() -> &'a str {
 fn get_home_dir() -> Result<PathBuf, String> {
     let home_dir = dirs::home_dir();
     match home_dir {
-        None => Err("Não foi possivel localizar a pasta home do usuario.".into()),
+        None => Err("Não foi possível localizar a pasta home do usuário.".into()),
         Some(data) => Ok(data),
     }
 }
@@ -55,7 +55,7 @@ pub fn create_or_get_ena_home_folder() -> Result<PathBuf, Box<dyn std::error::Er
     let mut home_folder = get_home_dir()?;
 
     if let Err(why) = read_enarc(&mut home_folder) {
-        println!("Ouve um erro ao ler o .enarc\n\nMotivo: {:?}", why);
+        println!("Houve um erro ao ler o .enarc\n\nMotivo: {:?}", why);
     }
     home_folder = home_folder.join(".ena-code");
     let path_ena_code_folder = Path::new(&home_folder);

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -11,9 +11,9 @@ use std::{
 
 pub fn launch(args: &LaunchOptions, config: &Config) {
     let path = Path::new(&config.profiles_folder);
-    let joined_path = path.join(&remove_caracteres(&args.profile, &config));
+    let joined_path = path.join(&remove_caracteres(&args.profile, config));
     let extension_folder = joined_path.join("extensions");
-    let configs_folder = config_folder(&config, &joined_path, &path);
+    let configs_folder = config_folder(config, &joined_path, path);
 
     let extension_folder = extension_folder.to_str();
     let configs_folder = configs_folder.to_str();

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -23,7 +23,7 @@ pub fn launch(args: &LaunchOptions, config: &Config) {
             None => {
                 if !check_profile_exists(&args.profile) {
                     let user_response = scanln::scanln!(
-                        "O profile {} não existe, gostaria de cria-lo [s,N]: ",
+                        "O profile {} não existe, gostaria de criá-lo? [s/N]: ",
                         &args.profile
                     );
 


### PR DESCRIPTION
For some reason, `clap`'s version changes when using `cargo install`, because `cargo install` ignores the `Cargo.lock` file.
This fixes the `clap`'s error and also fix some texts. 